### PR TITLE
feat: Dockerfile, USE_DOTENV, WAL mode, /sync from-pk, and manifest template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,6 @@ SLACK_SIGNING_SECRET=
 # make sure to enable encryption in the feature flags to use this!
 # highly recommened for production
 # ENCRYPTION_KEY=
-DATABASE_URL=sqlite://slackbot.db
+DATABASE_URL=sqlite://plura.db
 # no trailing / please!
-BASE_URL=https://slack-system-bot.wobbl.in
+BASE_URL=https://plura.foxes.codes

--- a/.sqlx/query-04fdce04aa13b6811ecdc0cbaa944ea11b0df9b267294dd734f41d9e9be91615.json
+++ b/.sqlx/query-04fdce04aa13b6811ecdc0cbaa944ea11b0df9b267294dd734f41d9e9be91615.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    members.id as 'id: Id<Trusted>'\n                FROM members\n                JOIN systems ON members.system_id = systems.id\n                WHERE members.id = $1 AND systems.owner_id = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "04fdce04aa13b6811ecdc0cbaa944ea11b0df9b267294dd734f41d9e9be91615"
+}

--- a/.sqlx/query-0b21ef3cf3bf9af1800134943518bc2b0f71f6e198a2479b99562e83d135af3c.json
+++ b/.sqlx/query-0b21ef3cf3bf9af1800134943518bc2b0f71f6e198a2479b99562e83d135af3c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                        DELETE FROM system_oauth_process\n                        WHERE csrf = $1\n                        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "0b21ef3cf3bf9af1800134943518bc2b0f71f6e198a2479b99562e83d135af3c"
+}

--- a/.sqlx/query-0d4a813957e336ae85b4300db9f05a1c13aefbb33b9b69590b604884bfa32732.json
+++ b/.sqlx/query-0d4a813957e336ae85b4300db9f05a1c13aefbb33b9b69590b604884bfa32732.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            owner_id as \"owner_id: user::Id<Trusted>\"\n        FROM\n            system_oauth_process\n        WHERE csrf = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "owner_id: user::Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0d4a813957e336ae85b4300db9f05a1c13aefbb33b9b69590b604884bfa32732"
+}

--- a/.sqlx/query-11e30e5ce59cf0822e6ebd41bf76a5af7c7e8cdd7667439452b502eaa1073697.json
+++ b/.sqlx/query-11e30e5ce59cf0822e6ebd41bf76a5af7c7e8cdd7667439452b502eaa1073697.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO aliases (member_id, system_id, alias)\n            VALUES ($1, $2, $3)\n            RETURNING\n                id as \"id: Id<Trusted>\",\n                member_id as \"member_id: member::Id<Trusted>\",\n                system_id as \"system_id: system::Id<Trusted>\",\n                alias\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: system::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "alias",
+        "ordinal": 3,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "11e30e5ce59cf0822e6ebd41bf76a5af7c7e8cdd7667439452b502eaa1073697"
+}

--- a/.sqlx/query-1d4b80a8d013d14f336ad19a87447d3419fa8e11ee98d93ef07687deedd77bcd.json
+++ b/.sqlx/query-1d4b80a8d013d14f336ad19a87447d3419fa8e11ee98d93ef07687deedd77bcd.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT\n                id as 'id: Id<Trusted>'\n            FROM members\n            WHERE id = $1 AND system_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1d4b80a8d013d14f336ad19a87447d3419fa8e11ee98d93ef07687deedd77bcd"
+}

--- a/.sqlx/query-1ec4205c64775babbb9e3390e0f473bdb5c4e6d17b8dcd3b2b3db274a3d0dc79.json
+++ b/.sqlx/query-1ec4205c64775babbb9e3390e0f473bdb5c4e6d17b8dcd3b2b3db274a3d0dc79.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                DELETE FROM aliases\n                WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "1ec4205c64775babbb9e3390e0f473bdb5c4e6d17b8dcd3b2b3db274a3d0dc79"
+}

--- a/.sqlx/query-2780cd7eb560384850f1ddf60b4f6c4b361e8ea7dec98d9661726573b4d2caa4.json
+++ b/.sqlx/query-2780cd7eb560384850f1ddf60b4f6c4b361e8ea7dec98d9661726573b4d2caa4.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT\n                id as 'id: Id<Trusted>'\n            FROM aliases\n            WHERE id = $1 AND system_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2780cd7eb560384850f1ddf60b4f6c4b361e8ea7dec98d9661726573b4d2caa4"
+}

--- a/.sqlx/query-2be64e1d7acc534d6afe2a205a463a8cf384951dca74c28ffb5b25da87f17309.json
+++ b/.sqlx/query-2be64e1d7acc534d6afe2a205a463a8cf384951dca74c28ffb5b25da87f17309.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE members SET enabled = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "2be64e1d7acc534d6afe2a205a463a8cf384951dca74c28ffb5b25da87f17309"
+}

--- a/.sqlx/query-2d94941a58c917d9a7d324b04ffd0a106d06565345a70f760eb5dc9c81ecff4d.json
+++ b/.sqlx/query-2d94941a58c917d9a7d324b04ffd0a106d06565345a70f760eb5dc9c81ecff4d.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    id as \"id: Id<Trusted>\",\n                    member_id as \"member_id: member::Id<Trusted>\",\n                    system_id as \"system_id: system::Id<Trusted>\",\n                    text,\n                    typ\n                FROM\n                    triggers\n                WHERE\n                   system_id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: system::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "text",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "typ",
+        "ordinal": 4,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2d94941a58c917d9a7d324b04ffd0a106d06565345a70f760eb5dc9c81ecff4d"
+}

--- a/.sqlx/query-2e030f837049b2992ed340b9ea6a091d2a9a06eb6eb72f1b4df5d8f3f863d3c7.json
+++ b/.sqlx/query-2e030f837049b2992ed340b9ea6a091d2a9a06eb6eb72f1b4df5d8f3f863d3c7.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            UPDATE systems\n            SET currently_fronting_member_id = $1\n            WHERE id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "2e030f837049b2992ed340b9ea6a091d2a9a06eb6eb72f1b4df5d8f3f863d3c7"
+}

--- a/.sqlx/query-4bcec39a53cba278c87c43b849749c6f7a91160c2514b05bb858e51cbb7f62eb.json
+++ b/.sqlx/query-4bcec39a53cba278c87c43b849749c6f7a91160c2514b05bb858e51cbb7f62eb.json
@@ -1,0 +1,80 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id as \"id: Id<Trusted>\",\n                system_id as \"system_id: system::Id<Trusted>\",\n                full_name,\n                display_name,\n                profile_picture_url,\n                title,\n                pronouns,\n                name_pronunciation,\n                name_recording_url,\n                enabled,\n                created_at as \"created_at: time::PrimitiveDateTime\"\n            FROM members\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: system::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "full_name",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "display_name",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "profile_picture_url",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "title",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "pronouns",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "name_pronunciation",
+        "ordinal": 7,
+        "type_info": "Text"
+      },
+      {
+        "name": "name_recording_url",
+        "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "enabled",
+        "ordinal": 9,
+        "type_info": "Bool"
+      },
+      {
+        "name": "created_at: time::PrimitiveDateTime",
+        "ordinal": 10,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "4bcec39a53cba278c87c43b849749c6f7a91160c2514b05bb858e51cbb7f62eb"
+}

--- a/.sqlx/query-4ec129418f30d63744d239ce6b430b2553dc8279119783b43f779bc643b1f9a6.json
+++ b/.sqlx/query-4ec129418f30d63744d239ce6b430b2553dc8279119783b43f779bc643b1f9a6.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id as \"id: Id<Trusted>\",\n                member_id as \"member_id: member::Id<Trusted>\",\n                system_id as \"system_id: system::Id<Trusted>\",\n                text,\n                typ\n            FROM\n                triggers\n            WHERE member_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: system::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "text",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "typ",
+        "ordinal": 4,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4ec129418f30d63744d239ce6b430b2553dc8279119783b43f779bc643b1f9a6"
+}

--- a/.sqlx/query-6f8391494c3d7a309fba8e621cedf525d814b05ad3b824d51275a79d616e46d2.json
+++ b/.sqlx/query-6f8391494c3d7a309fba8e621cedf525d814b05ad3b824d51275a79d616e46d2.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    id as \"id: Id<Trusted>\",\n                    member_id as \"member_id: member::Id<Trusted>\",\n                    system_id as \"system_id: system::Id<Trusted>\",\n                    alias\n                FROM\n                    aliases\n                WHERE\n                   system_id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: system::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "alias",
+        "ordinal": 3,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6f8391494c3d7a309fba8e621cedf525d814b05ad3b824d51275a79d616e46d2"
+}

--- a/.sqlx/query-72b92254bed36439057fe11e11e8da8e7c24b48da20a885fb6b21d8ee4b8aa63.json
+++ b/.sqlx/query-72b92254bed36439057fe11e11e8da8e7c24b48da20a885fb6b21d8ee4b8aa63.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    id as \"id: Id<Trusted>\",\n                    member_id as \"member_id: member::Id<Trusted>\",\n                    message_id\n                FROM\n                    message_logs\n                WHERE\n                   member_id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "message_id",
+        "ordinal": 2,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "72b92254bed36439057fe11e11e8da8e7c24b48da20a885fb6b21d8ee4b8aa63"
+}

--- a/.sqlx/query-74767c5301f932a80fde568387d0d1d3543e92d5c6c134981b1ace845c569135.json
+++ b/.sqlx/query-74767c5301f932a80fde568387d0d1d3543e92d5c6c134981b1ace845c569135.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT\n                id as 'id: Id<Trusted>'\n            FROM triggers\n            WHERE id = $1 AND system_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "74767c5301f932a80fde568387d0d1d3543e92d5c6c134981b1ace845c569135"
+}

--- a/.sqlx/query-7848fe19184280fc87ba466b55f8fa61ac7f7d5987c78fe561ee44da46244ef1.json
+++ b/.sqlx/query-7848fe19184280fc87ba466b55f8fa61ac7f7d5987c78fe561ee44da46244ef1.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO system_oauth_process (owner_id, csrf)\n            VALUES ($1, $2)\n            ON CONFLICT (owner_id) DO UPDATE SET csrf = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "7848fe19184280fc87ba466b55f8fa61ac7f7d5987c78fe561ee44da46244ef1"
+}

--- a/.sqlx/query-7e43c0e944c2a60ef369978b848680384a8a5aef846941930c777dc94ba4b60e.json
+++ b/.sqlx/query-7e43c0e944c2a60ef369978b848680384a8a5aef846941930c777dc94ba4b60e.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id as \"id: Id<Trusted>\",\n                owner_id as \"owner_id: user::Id<Trusted>\",\n                currently_fronting_member_id as \"currently_fronting_member_id: member::Id<Trusted>\",\n                auto_switch_on_trigger,\n                slack_oauth_token,\n                created_at as \"created_at: time::PrimitiveDateTime\"\n            FROM\n                systems\n            WHERE owner_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "owner_id: user::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "currently_fronting_member_id: member::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "auto_switch_on_trigger",
+        "ordinal": 3,
+        "type_info": "Bool"
+      },
+      {
+        "name": "slack_oauth_token",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_at: time::PrimitiveDateTime",
+        "ordinal": 5,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7e43c0e944c2a60ef369978b848680384a8a5aef846941930c777dc94ba4b60e"
+}

--- a/.sqlx/query-83319616c9a81980005676b35befdd41ec95a3117dc8b7f4215a54bf855950ca.json
+++ b/.sqlx/query-83319616c9a81980005676b35befdd41ec95a3117dc8b7f4215a54bf855950ca.json
@@ -1,0 +1,80 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id as \"id: member::Id<Trusted>\",\n                system_id as \"system_id: Id<Trusted>\",\n                full_name,\n                display_name,\n                profile_picture_url,\n                title,\n                pronouns,\n                name_pronunciation,\n                name_recording_url,\n                enabled,\n                created_at as \"created_at: time::PrimitiveDateTime\"\n            FROM\n                members\n            WHERE system_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: member::Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "full_name",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "display_name",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "profile_picture_url",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "title",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "pronouns",
+        "ordinal": 6,
+        "type_info": "Text"
+      },
+      {
+        "name": "name_pronunciation",
+        "ordinal": 7,
+        "type_info": "Text"
+      },
+      {
+        "name": "name_recording_url",
+        "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "enabled",
+        "ordinal": 9,
+        "type_info": "Bool"
+      },
+      {
+        "name": "created_at: time::PrimitiveDateTime",
+        "ordinal": 10,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "83319616c9a81980005676b35befdd41ec95a3117dc8b7f4215a54bf855950ca"
+}

--- a/.sqlx/query-8bd32a0c8934610e14a9fe524220e92423d9e38aa7c45198d0ec3a215c12d6c8.json
+++ b/.sqlx/query-8bd32a0c8934610e14a9fe524220e92423d9e38aa7c45198d0ec3a215c12d6c8.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            UPDATE members\n            SET full_name = $1, display_name = $2, profile_picture_url = $3, title = $4, pronouns = $5, name_pronunciation = $6, name_recording_url = $7\n            WHERE id = $8\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 8
+    },
+    "nullable": []
+  },
+  "hash": "8bd32a0c8934610e14a9fe524220e92423d9e38aa7c45198d0ec3a215c12d6c8"
+}

--- a/.sqlx/query-a0857365f6f46169cedc2098d1c0c282b4380aac28674f37ba08aeea83626dee.json
+++ b/.sqlx/query-a0857365f6f46169cedc2098d1c0c282b4380aac28674f37ba08aeea83626dee.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id as \"id: Id<Trusted>\",\n                owner_id as \"owner_id: user::Id<Trusted>\",\n                currently_fronting_member_id as \"currently_fronting_member_id: member::Id<Trusted>\",\n                auto_switch_on_trigger,\n                slack_oauth_token,\n                created_at as \"created_at: time::PrimitiveDateTime\"\n            FROM systems\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "owner_id: user::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "currently_fronting_member_id: member::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "auto_switch_on_trigger",
+        "ordinal": 3,
+        "type_info": "Bool"
+      },
+      {
+        "name": "slack_oauth_token",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_at: time::PrimitiveDateTime",
+        "ordinal": 5,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a0857365f6f46169cedc2098d1c0c282b4380aac28674f37ba08aeea83626dee"
+}

--- a/.sqlx/query-b0e278b61cecabadfe070e2806fc0303fedc4c86b81c9cada598b63ecb47badf.json
+++ b/.sqlx/query-b0e278b61cecabadfe070e2806fc0303fedc4c86b81c9cada598b63ecb47badf.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id as \"id: Id<Trusted>\",\n                member_id as \"member_id: member::Id<Trusted>\",\n                message_id\n            FROM\n                message_logs\n            WHERE message_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "message_id",
+        "ordinal": 2,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b0e278b61cecabadfe070e2806fc0303fedc4c86b81c9cada598b63ecb47badf"
+}

--- a/.sqlx/query-bfab0dd41442bcf5fede67398ad5453d7e723a5df43a540d44cf83f83e0dbd11.json
+++ b/.sqlx/query-bfab0dd41442bcf5fede67398ad5453d7e723a5df43a540d44cf83f83e0dbd11.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO triggers (member_id, system_id, typ, text)\n            VALUES ($1, $2, $3, $4)\n            RETURNING\n                id as \"id: Id<Trusted>\",\n                member_id as \"member_id: member::Id<Trusted>\",\n                system_id as \"system_id: system::Id<Trusted>\",\n                typ,\n                text\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: system::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "typ",
+        "ordinal": 3,
+        "type_info": "Integer"
+      },
+      {
+        "name": "text",
+        "ordinal": 4,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bfab0dd41442bcf5fede67398ad5453d7e723a5df43a540d44cf83f83e0dbd11"
+}

--- a/.sqlx/query-c1330cef195b203f42fd1916c45a59715621353db22d5ee3f4c2b56b711241b8.json
+++ b/.sqlx/query-c1330cef195b203f42fd1916c45a59715621353db22d5ee3f4c2b56b711241b8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT enabled FROM members WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "name": "enabled",
+        "ordinal": 0,
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c1330cef195b203f42fd1916c45a59715621353db22d5ee3f4c2b56b711241b8"
+}

--- a/.sqlx/query-c9de717842b3012917cfef30428e98666a25504d5c03f222afecfefb759f00d7.json
+++ b/.sqlx/query-c9de717842b3012917cfef30428e98666a25504d5c03f222afecfefb759f00d7.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO members (full_name, display_name, profile_picture_url, title, pronouns, name_pronunciation, name_recording_url, system_id)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n            RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 8
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c9de717842b3012917cfef30428e98666a25504d5c03f222afecfefb759f00d7"
+}

--- a/.sqlx/query-d28d88839f91859aa410470a5240d65bb0f46a99a198c06ff4d886bf8ba94784.json
+++ b/.sqlx/query-d28d88839f91859aa410470a5240d65bb0f46a99a198c06ff4d886bf8ba94784.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                DELETE FROM message_logs\n                WHERE message_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "d28d88839f91859aa410470a5240d65bb0f46a99a198c06ff4d886bf8ba94784"
+}

--- a/.sqlx/query-dba6daa7ea09507aa91463a41e78424ae372d7e0c8b1bf2150d4e6588da2e9ab.json
+++ b/.sqlx/query-dba6daa7ea09507aa91463a41e78424ae372d7e0c8b1bf2150d4e6588da2e9ab.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT\n                member_id AS 'id: Id<Trusted>'\n            FROM aliases\n            WHERE alias = $1 AND system_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "dba6daa7ea09507aa91463a41e78424ae372d7e0c8b1bf2150d4e6588da2e9ab"
+}

--- a/.sqlx/query-dbf3ee22f8ee9f2935acf109c4e620b5a5522a05a3def3a8d12140f77dc486f4.json
+++ b/.sqlx/query-dbf3ee22f8ee9f2935acf109c4e620b5a5522a05a3def3a8d12140f77dc486f4.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    members.id as \"id: member::Id<Trusted>\",\n                    display_name,\n                    profile_picture_url,\n                    triggers.text as trigger_text,\n                    triggers.typ\n                FROM\n                    members\n                JOIN\n                    triggers ON members.id = triggers.member_id\n                WHERE\n                    -- See trigger.rs file for all types and names\n                    members.enabled = TRUE AND\n                    ((triggers.typ = 0 AND $1 LIKE '%' || triggers.text) OR\n                    (triggers.typ = 1 AND $1 LIKE triggers.text || '%'))\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: member::Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "display_name",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "profile_picture_url",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "trigger_text",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "typ",
+        "ordinal": 4,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "dbf3ee22f8ee9f2935acf109c4e620b5a5522a05a3def3a8d12140f77dc486f4"
+}

--- a/.sqlx/query-df793c15ed1ca3a4af1148ec9fec377aab3ccf7cfc38250515b4301f21f8809b.json
+++ b/.sqlx/query-df793c15ed1ca3a4af1148ec9fec377aab3ccf7cfc38250515b4301f21f8809b.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            UPDATE triggers\n            SET\n                typ = coalesce($2, typ),\n                text = coalesce($3, text)\n            WHERE id = $1\n            RETURNING\n                id as \"id: Id<Trusted>\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "df793c15ed1ca3a4af1148ec9fec377aab3ccf7cfc38250515b4301f21f8809b"
+}

--- a/.sqlx/query-e811964cfde379fed00e5941f976b9a384ca7c76324209ea15351a01f4dd5d64.json
+++ b/.sqlx/query-e811964cfde379fed00e5941f976b9a384ca7c76324209ea15351a01f4dd5d64.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            id as \"id: system::Id<Trusted>\"\n        FROM\n            systems\n    ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: system::Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e811964cfde379fed00e5941f976b9a384ca7c76324209ea15351a01f4dd5d64"
+}

--- a/.sqlx/query-e86320673d997dea93a80b855e7492b06aacee4ef9c6513f9bb745c03e69b2ac.json
+++ b/.sqlx/query-e86320673d997dea93a80b855e7492b06aacee4ef9c6513f9bb745c03e69b2ac.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT\n                    members.id,\n                    display_name,\n                    full_name,\n                    enabled,\n                    GROUP_CONCAT(aliases.alias, ', ') as aliases\n                FROM\n                    members\n                JOIN\n                    aliases ON members.id = aliases.member_id\n                WHERE\n                    members.system_id = $1\n                GROUP BY members.id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "display_name",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "full_name",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "enabled",
+        "ordinal": 3,
+        "type_info": "Bool"
+      },
+      {
+        "name": "aliases",
+        "ordinal": 4,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e86320673d997dea93a80b855e7492b06aacee4ef9c6513f9bb745c03e69b2ac"
+}

--- a/.sqlx/query-e8684fdb0052090f83b4e7a6950e8c36a75390ca1f24e2da867db5d4a2589224.json
+++ b/.sqlx/query-e8684fdb0052090f83b4e7a6950e8c36a75390ca1f24e2da867db5d4a2589224.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                DELETE FROM triggers\n                WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "e8684fdb0052090f83b4e7a6950e8c36a75390ca1f24e2da867db5d4a2589224"
+}

--- a/.sqlx/query-f1a53ac9fd2ed276b8b3b1f034f4ddcf493423533287f68b39aa81fe22d0297b.json
+++ b/.sqlx/query-f1a53ac9fd2ed276b8b3b1f034f4ddcf493423533287f68b39aa81fe22d0297b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                UPDATE aliases\n                SET alias = $2\n                WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "f1a53ac9fd2ed276b8b3b1f034f4ddcf493423533287f68b39aa81fe22d0297b"
+}

--- a/.sqlx/query-f29cae5d678ee34feb0d2811cbe283976da87c3fc97e279e74e0edde8d540544.json
+++ b/.sqlx/query-f29cae5d678ee34feb0d2811cbe283976da87c3fc97e279e74e0edde8d540544.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT\n                id as \"id: Id<Trusted>\",\n                member_id as \"member_id: member::Id<Trusted>\",\n                system_id as \"system_id: system::Id<Trusted>\",\n                alias\n            FROM\n                aliases\n            WHERE member_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "system_id: system::Id<Trusted>",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "alias",
+        "ordinal": 3,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f29cae5d678ee34feb0d2811cbe283976da87c3fc97e279e74e0edde8d540544"
+}

--- a/.sqlx/query-f67cd8c94467cfbaefe6bbfb8940144eda3cb92cf447d6d77736837e2cc04b9e.json
+++ b/.sqlx/query-f67cd8c94467cfbaefe6bbfb8940144eda3cb92cf447d6d77736837e2cc04b9e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                  INSERT INTO systems (owner_id, slack_oauth_token)\n                  VALUES ($1, $2)\n                  ON CONFLICT (owner_id) DO UPDATE SET slack_oauth_token = $2\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "f67cd8c94467cfbaefe6bbfb8940144eda3cb92cf447d6d77736837e2cc04b9e"
+}

--- a/.sqlx/query-fb70767a8f81b4a0ff80331e9a2a3ef4d5b84f8bbaf713b6cc2db988786ed9b4.json
+++ b/.sqlx/query-fb70767a8f81b4a0ff80331e9a2a3ef4d5b84f8bbaf713b6cc2db988786ed9b4.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT currently_fronting_member_id as \"id: member::Id<Trusted>\"\n            FROM systems\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: member::Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "fb70767a8f81b4a0ff80331e9a2a3ef4d5b84f8bbaf713b6cc2db988786ed9b4"
+}

--- a/.sqlx/query-fd7f6f5bb12f059c5c8ffb310d6ed2d5d4c9d525fd1bf2ee948fb1c07a6115f1.json
+++ b/.sqlx/query-fd7f6f5bb12f059c5c8ffb310d6ed2d5d4c9d525fd1bf2ee948fb1c07a6115f1.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                INSERT INTO message_logs (member_id, message_id)\n                VALUES ($1, $2)\n                RETURNING\n                    id as \"id: Id<Trusted>\",\n                    member_id as \"member_id: member::Id<Trusted>\",\n                    message_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: Id<Trusted>",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "member_id: member::Id<Trusted>",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "message_id",
+        "ordinal": 2,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fd7f6f5bb12f059c5c8ffb310d6ed2d5d4c9d525fd1bf2ee948fb1c07a6115f1"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,24 +624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "git+https://github.com/allan2/dotenvy#86c0d6dd2938e615135813df9e3274bf8f42c455"
-dependencies = [
- "dotenvy-macros",
-]
-
-[[package]]
-name = "dotenvy-macros"
-version = "0.15.7"
-source = "git+https://github.com/allan2/dotenvy#86c0d6dd2938e615135813df9e3274bf8f42c455"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,7 +1726,6 @@ dependencies = [
  "clap",
  "derive_more",
  "displaydoc",
- "dotenvy 0.15.7 (git+https://github.com/allan2/dotenvy)",
  "error-stack",
  "futures",
  "http-body-util",
@@ -1753,6 +1734,7 @@ dependencies = [
  "menv",
  "oauth2",
  "redact",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -2600,7 +2582,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
- "dotenvy 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenvy",
  "either",
  "heck",
  "hex",
@@ -2632,7 +2614,7 @@ dependencies = [
  "bytes",
  "crc",
  "digest",
- "dotenvy 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenvy",
  "either",
  "futures-channel",
  "futures-core",
@@ -2673,7 +2655,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "crc",
- "dotenvy 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenvy",
  "etcetera",
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "git+https://github.com/allan2/dotenvy#fa25166994d6978bd2e002f0ed190c0c39674ebe"
+dependencies = [
+ "dotenvy-macros",
+]
+
+[[package]]
+name = "dotenvy-macros"
+version = "0.15.7"
+source = "git+https://github.com/allan2/dotenvy#fa25166994d6978bd2e002f0ed190c0c39674ebe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1744,7 @@ dependencies = [
  "clap",
  "derive_more",
  "displaydoc",
+ "dotenvy 0.15.7 (git+https://github.com/allan2/dotenvy)",
  "error-stack",
  "futures",
  "http-body-util",
@@ -2582,7 +2601,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
- "dotenvy",
+ "dotenvy 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "either",
  "heck",
  "hex",
@@ -2614,7 +2633,7 @@ dependencies = [
  "bytes",
  "crc",
  "digest",
- "dotenvy",
+ "dotenvy 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "either",
  "futures-channel",
  "futures-core",
@@ -2655,7 +2674,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "crc",
- "dotenvy",
+ "dotenvy 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "etcetera",
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.45.1", features = ["rt", "macros", "rt-multi-thread"] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+dotenvy = { git = "https://github.com/allan2/dotenvy", features = ["macros"] }
 
 url = "2.5.4"
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.45.1", features = ["rt", "macros", "rt-multi-thread"] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-dotenvy = { git = "https://github.com/allan2/dotenvy", features = ["macros"] }
+
 url = "2.5.4"
 serde_json = "1.0.140"
 tower-http = { version = "0.6.6", features = ["trace"] }
@@ -49,6 +49,7 @@ derive_more = { version = "2.0.1", features = ["from"] }
 futures = "0.3.31"
 indoc = "2.0.6"
 tracing-journald = "0.3.1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
 [features]
 encrypt = ["libsqlite3-sys/bundled-sqlcipher"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM rust:1.92 AS builder
+
+ARG APP_NAME=plura
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y \
+    clang \
+    llvm-dev \
+    libclang-dev \
+    pkg-config \
+    sqlite3 \
+    libsqlite3-dev \
+    git \
+    musl-tools
+
+COPY . .
+
+ENV SQLX_OFFLINE=true
+
+RUN rustup target add x86_64-unknown-linux-musl && \
+    cargo build --release --target x86_64-unknown-linux-musl && \
+    cp ./target/x86_64-unknown-linux-musl/release/$APP_NAME /bin/server
+
+FROM alpine:latest AS final
+
+ARG UID=10001
+
+# create non-root user
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+
+# create app + data dirs
+WORKDIR /app
+RUN mkdir -p /data && \
+    chown -R appuser:appuser /app /data
+
+# copy binary
+COPY --from=builder /bin/server /app/plura
+
+# switch to non-root
+USER appuser
+
+EXPOSE 8080
+
+CMD ["./plura"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A slack bot designed to make the lives of plural systems easier. Inspired by Plu
 
 https://github.com/user-attachments/assets/cff44cd0-ed4f-4e28-9bac-db6f3a60e03d
 
-I'm not plural myself, but I do know a lot of Hack Club members that are plural and do want an easier way to differentiate between alters. Thus, I made this.
+I'm plural myself (endoftimee), and I am not (Suya), but I do know a lot of Hack Club members that are plural and do want an easier way to differentiate between alters. Thus, I made this.
 It works similarly to PluralKit, by basically rewriting sent messages under different members using Slack's API.
 
 ## Features
@@ -19,6 +19,7 @@ It works similarly to PluralKit, by basically rewriting sent messages under diff
   - Message info (i.e. the profile of the member that sent it)
   - Message reproxying (i.e. sending a message under a different user after it's been sent)
 - Set and view information about a member
+- Import members from PluralKit via `/sync from-pk <token>`
 
 ## AI Usage in this project
 (_Required for Summer Of Making by Hack Club_)

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,138 @@
+{
+    "display_information": {
+        "name": "Plura",
+        "description": "A bot designed to make the lives of plural systems easier",
+        "background_color": "#0b0824",
+        "long_description": "Plura is a bot that can replace user-sent messages under a \"pseudo-account\" of a systems member profile using custom display information.\r\n\r\nThis is useful for multiple people sharing one body (aka. systems), people who wish to role-play as different characters without having multiple Slack profiles, or anyone else who may want to post messages under a different identity from the same Slack account.\r\n\r\nDue to Slack's limitations, these messages will show up with the [APP] tag - however, they are not apps/bots. You can use message actions to find who the message was sent by.\r\n\r\nIf you wish to use the bot yourself, you can start with `/system help` and `/members help`."
+    },
+    "features": {
+        "bot_user": {
+            "display_name": "Plura",
+            "always_online": false
+        },
+        "shortcuts": [
+            {
+                "name": "Reproxy Message",
+                "type": "message",
+                "callback_id": "reproxy_message",
+                "description": "Resends a message sent by either your main account or one of your system members profiles under another members profile."
+            },
+            {
+                "name": "Get message information",
+                "type": "message",
+                "callback_id": "message_info",
+                "description": "Get info about who sent this message"
+            },
+            {
+                "name": "Delete message",
+                "type": "message",
+                "callback_id": "delete_message",
+                "description": "Deletes a message sent by one of your system members"
+            },
+            {
+                "name": "Edit message",
+                "type": "message",
+                "callback_id": "edit_message",
+                "description": "Edits a message sent by a member"
+            }
+        ],
+        "slash_commands": [
+            {
+                "command": "/members",
+                "url": "https://YOUR_DOMAIN/command",
+                "description": "Manage system members",
+                "usage_hint": "help",
+                "should_escape": true
+            },
+            {
+                "command": "/system",
+                "url": "https://YOUR_DOMAIN/command",
+                "description": "Manage or create your system",
+                "usage_hint": "help",
+                "should_escape": true
+            },
+            {
+                "command": "/triggers",
+                "url": "https://YOUR_DOMAIN/command",
+                "description": "Manage triggers",
+                "usage_hint": "help",
+                "should_escape": true
+            },
+            {
+                "command": "/aliases",
+                "url": "https://YOUR_DOMAIN/command",
+                "description": "Manage aliases",
+                "usage_hint": "help",
+                "should_escape": true
+            },
+            {
+                "command": "/sync",
+                "url": "https://YOUR_DOMAIN/command",
+                "description": "Sync members from PluralKit",
+                "usage_hint": "from-pk <token>",
+                "should_escape": false
+            },
+            {
+                "command": "/explain",
+                "url": "https://YOUR_DOMAIN/command",
+                "description": "Explains how this bot works",
+                "should_escape": false
+            }
+        ]
+    },
+    "oauth_config": {
+        "redirect_urls": [
+            "https://YOUR_DOMAIN"
+        ],
+        "scopes": {
+            "user": [
+                "users:read",
+                "chat:write",
+                "channels:history",
+                "groups:history",
+                "im:history",
+                "mpim:history"
+            ],
+            "bot": [
+                "channels:history",
+                "chat:write",
+                "chat:write.customize",
+                "chat:write.public",
+                "commands",
+                "groups:history",
+                "im:history",
+                "mpim:history",
+                "groups:write",
+                "mpim:write",
+                "mpim:read",
+                "groups:read",
+                "im:write"
+            ]
+        },
+        "pkce_enabled": false
+    },
+    "settings": {
+        "event_subscriptions": {
+            "request_url": "https://YOUR_DOMAIN/push",
+            "user_events": [
+                "message.channels",
+                "message.groups",
+                "message.im",
+                "message.mpim"
+            ],
+            "bot_events": [
+                "message.channels",
+                "message.groups",
+                "message.im",
+                "message.mpim"
+            ]
+        },
+        "interactivity": {
+            "is_enabled": true,
+            "request_url": "https://YOUR_DOMAIN/interaction"
+        },
+        "org_deploy_enabled": false,
+        "socket_mode_enabled": false,
+        "token_rotation_enabled": false
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 mod alias;
 mod member;
+mod sync;
 mod system;
 mod trigger;
 
@@ -20,6 +21,7 @@ use slack_morphism::prelude::*;
 use tracing::{Level, debug, error, trace};
 
 use member::Member;
+use sync::Sync;
 use system::System;
 use trigger::Trigger;
 
@@ -36,6 +38,8 @@ enum Command {
     Triggers(Trigger),
     #[clap(subcommand)]
     Aliases(Alias),
+    #[clap(subcommand)]
+    Sync(Sync),
     /// Provides an explanation of this bot.
     Explain,
 }
@@ -65,6 +69,10 @@ impl Command {
                 .run(event, state)
                 .await
                 .change_context(CommandError::Aliases),
+            Self::Sync(sync) => sync
+                .run(event, client, state)
+                .await
+                .change_context(CommandError::Sync),
             Self::Explain => Ok(Self::explain()),
         }
     }
@@ -73,13 +81,13 @@ impl Command {
         SlackCommandEventResponse::new(
             SlackMessageContent::new().with_text(
                 indoc::indoc! {r#"
-                Slack System Bot is a bot that can replace user-sent messages under a "pseudo-account" of a systems member profile using custom display information.
+                Plura is a bot that can replace user-sent messages under a "pseudo-account" of a systems member profile using custom display information.
 
                 This is useful for multiple people sharing one body (aka. systems), people who wish to role-play as different characters without having multiple Slack profiles, or anyone else who may want to post messages under a different identity from the same Slack account.
 
                 Due to Slack's limitations, these messages will show up with the [APP] tag - however, they are not apps/bots. You can use message actions to find who the message was sent by.
 
-                If you wish to use the bot yourself, you can start with `/system help` and `/members help`.
+                If you wish to use the bot yourself, you can start with `/system help` and `/members help`. Other commands: `/triggers help`, `/aliases help`, `/sync help`.
                 "#}.into(),
             ),
         ).with_response_type(SlackMessageResponseType::InChannel)
@@ -96,9 +104,10 @@ enum CommandError {
     System,
     /// Error running the aliases command
     Aliases,
+    /// Error running the sync command
+    Sync,
 }
 
-// TO-DO: figure out error handling
 #[tracing::instrument(skip(environment, event))]
 pub async fn process_command_event(
     Extension(environment): Extension<Arc<SlackHyperListenerEnvironment>>,
@@ -110,7 +119,7 @@ pub async fn process_command_event(
     match command_event_callback(event, client, state).await {
         Ok(response) => Json(response),
         Err(e) => {
-            error!(error = ?e, "Error processing command event");
+            tracing::error!(error = ?e, "Error processing command event");
             Json(SlackCommandEventResponse::new(
                 SlackMessageContent::new()
                     .with_text("Error processing command! Logged to developers".into()),
@@ -150,7 +159,7 @@ async fn command_event_callback(
                     error!(error = ?e, "Error running command");
                     Ok(SlackCommandEventResponse::new(
                         SlackMessageContent::new().with_text(
-                            "Error running command! TODO: show error info on slack".into(),
+                            format!("Error running command: {e}").into(),
                         ),
                     ))
                 }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use error_stack::{Result, ResultExt};
+use reqwest::Client;
+use serde::Deserialize;
+use slack_morphism::prelude::*;
+
+use crate::{
+    fetch_system,
+    models::{member, user},
+};
+
+#[derive(thiserror::Error, displaydoc::Display, Debug)]
+pub enum CommandError {
+    /// Error calling the database
+    Sqlx,
+    /// Error calling the PluralKit API
+    PluralKit,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum Sync {
+    /// Import members from PluralKit. Run in a DM to keep your token private.
+    FromPk {
+        /// Your PluralKit token (from pluralkit.me/settings)
+        token: String,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+struct PkMember {
+    name: String,
+    display_name: Option<String>,
+    avatar_url: Option<String>,
+    pronouns: Option<String>,
+}
+
+impl Sync {
+    #[tracing::instrument(skip_all)]
+    pub async fn run(
+        self,
+        event: SlackCommandEvent,
+        _client: Arc<SlackHyperClient>,
+        state: SlackClientEventsUserState,
+    ) -> Result<SlackCommandEventResponse, CommandError> {
+        let states = state.read().await;
+        let user_state = states.get_user_state::<user::State>().unwrap();
+
+        match self {
+            Self::FromPk { token } => {
+                fetch_system!(event, user_state => system_id);
+
+                let http = Client::new();
+                let pk_members = http
+                    .get("https://api.pluralkit.me/v2/systems/@me/members")
+                    .header("User-Agent", "Plura/0.1 (https://github.com/Suya1671/plura)")
+                    .header("Authorization", token.trim())
+                    .send()
+                    .await
+                    .change_context(CommandError::PluralKit)
+                    .attach_printable("Failed to reach PluralKit API")?
+                    .error_for_status()
+                    .change_context(CommandError::PluralKit)
+                    .attach_printable("PluralKit API returned an error — is your token correct?")?
+                    .json::<Vec<PkMember>>()
+                    .await
+                    .change_context(CommandError::PluralKit)
+                    .attach_printable("Failed to parse PluralKit API response")?;
+
+                let count = pk_members.len();
+
+                for pk_member in pk_members {
+                    let display_name = pk_member
+                        .display_name
+                        .unwrap_or_else(|| pk_member.name.clone());
+                    member::View {
+                        full_name: pk_member.name,
+                        display_name,
+                        profile_picture_url: pk_member.avatar_url,
+                        pronouns: pk_member.pronouns,
+                        title: None,
+                        name_pronunciation: None,
+                        name_recording_url: None,
+                    }
+                    .add(system_id, &user_state.db)
+                    .await
+                    .change_context(CommandError::Sqlx)?;
+                }
+
+                Ok(SlackCommandEventResponse::new(
+                    SlackMessageContent::new().with_text(
+                        format!("Imported {count} member(s) from PluralKit!").into(),
+                    ),
+                ))
+            }
+        }
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -3,8 +3,9 @@ use menv::require_envs;
 require_envs! {
     (assert_env_vars, any_set, gen_help);
 
-    slack_app_token, "SLACK_APP_TOKEN", String,
-    "SLACK_APP_TOKEN should be set to the bot's app token";
+    // slack_app_token, "SLACK_APP_TOKEN", Option<String>,
+    // "SLACK_APP_TOKEN should be set to the bot's app token (required for socket mode)";
+
 
     slack_bot_token, "SLACK_BOT_TOKEN", String,
     "SLACK_BOT_TOKEN should be set to the bot's user token";

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,41 +45,10 @@ enum Error {
     Initialization,
 }
 
+#[dotenvy::load(required = false)]
 #[tokio::main]
 #[tracing::instrument]
 async fn main() -> error_stack::Result<ExitCode, Error> {
-    if std::env::var("USE_DOTENV").is_ok() {
-        // Custom, minimal .env loader to avoid depending on crate helpers in the build image.
-        // This reads .env, parses simple KEY=VALUE lines, strips optional surrounding quotes,
-        // and sets the variables into the environment for the process.
-        if let Ok(content) = std::fs::read_to_string(".env") {
-            for raw_line in content.lines() {
-                let line = raw_line.trim();
-                if line.is_empty() || line.starts_with('#') {
-                    continue;
-                }
-                // Split on the first '='
-                if let Some(eq) = line.find('=') {
-                    let key = line[..eq].trim();
-                    let mut val = line[eq + 1..].trim().to_string();
-                    // Strip surrounding quotes if present
-                    if (val.starts_with('"') && val.ends_with('"'))
-                        || (val.starts_with('\'') && val.ends_with('\''))
-                    {
-                        if val.len() >= 2 {
-                            val = val[1..val.len() - 1].to_string();
-                        }
-                    }
-                    // Only set if key non-empty
-                    if !key.is_empty() {
-                        unsafe { std::env::set_var(key, val) };
-                    }
-                }
-            }
-        } else {
-            tracing::debug!(".env requested via USE_DOTENV but .env file not found");
-        }
-    }
     let console_subscriber = tracing_subscriber::fmt::layer().pretty();
     let error_subscriber = tracing_error::ErrorLayer::default();
     let env_subscriber = EnvFilter::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ use tracing::{debug, info, info_span, level_filters::LevelFilter};
 use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// The slack app token. Used for socket mode if we ever decide to use it.
-pub static APP_TOKEN: LazyLock<SlackApiToken> =
-    LazyLock::new(|| SlackApiToken::new(env::slack_app_token().into()));
+// pub static APP_TOKEN: LazyLock<Option<SlackApiToken>> =
+//     LazyLock::new(|| env::slack_app_token().map(|t| SlackApiToken::new(t.into())));
 
 /// The slack bot token. Used for most interactions
 pub static BOT_TOKEN: LazyLock<SlackApiToken> =
@@ -45,10 +45,41 @@ enum Error {
     Initialization,
 }
 
-#[dotenvy::load]
 #[tokio::main]
 #[tracing::instrument]
 async fn main() -> error_stack::Result<ExitCode, Error> {
+    if std::env::var("USE_DOTENV").is_ok() {
+        // Custom, minimal .env loader to avoid depending on crate helpers in the build image.
+        // This reads .env, parses simple KEY=VALUE lines, strips optional surrounding quotes,
+        // and sets the variables into the environment for the process.
+        if let Ok(content) = std::fs::read_to_string(".env") {
+            for raw_line in content.lines() {
+                let line = raw_line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                // Split on the first '='
+                if let Some(eq) = line.find('=') {
+                    let key = line[..eq].trim();
+                    let mut val = line[eq + 1..].trim().to_string();
+                    // Strip surrounding quotes if present
+                    if (val.starts_with('"') && val.ends_with('"'))
+                        || (val.starts_with('\'') && val.ends_with('\''))
+                    {
+                        if val.len() >= 2 {
+                            val = val[1..val.len() - 1].to_string();
+                        }
+                    }
+                    // Only set if key non-empty
+                    if !key.is_empty() {
+                        unsafe { std::env::set_var(key, val) };
+                    }
+                }
+            }
+        } else {
+            tracing::debug!(".env requested via USE_DOTENV but .env file not found");
+        }
+    }
     let console_subscriber = tracing_subscriber::fmt::layer().pretty();
     let error_subscriber = tracing_error::ErrorLayer::default();
     let env_subscriber = EnvFilter::builder()
@@ -86,6 +117,18 @@ async fn main() -> error_stack::Result<ExitCode, Error> {
     let pool = SqlitePool::connect_with(options)
         .await
         .attach_printable("Error connecting to database")
+        .change_context(Error::Initialization)?;
+
+    sqlx::query("PRAGMA journal_mode=WAL;")
+        .execute(&pool)
+        .await
+        .attach_printable("Error setting WAL mode")
+        .change_context(Error::Initialization)?;
+
+    sqlx::query("PRAGMA synchronous=NORMAL;")
+        .execute(&pool)
+        .await
+        .attach_printable("Error setting synchronous mode")
         .change_context(Error::Initialization)?;
 
     sqlx::migrate!()


### PR DESCRIPTION
## Summary

- **feat(docker):** Add Dockerfile for production deployment with SQLx offline query cache (`.sqlx/`) so the image can build without a live database
- **feat(env):** Add `USE_DOTENV=1` env var for optional `.env` loading in development; remove unused `SLACK_APP_TOKEN` requirement; enable SQLite WAL mode + `synchronous=NORMAL` for better write performance
- **feat(sync):** Add `/sync from-pk <token>` command to import members from PluralKit — fetches from `api.pluralkit.me/v2/systems/@me/members` and inserts via the existing `member::View::add()` path
- **docs:** Add `manifest.json` template with `YOUR_DOMAIN` placeholders so self-hosters can paste it straight into api.slack.com; update README features list; fix bot name in `/explain` text (was "Slack System Bot"); list all commands in `/explain` output

## Notes

- `/sync` token comes from `pk;token` in Discord DMs with PluralKit. Run it in a DM to keep the token out of channel history.
- `reqwest` added as a dependency (rustls-tls, no default features) for the PluralKit API call
- `.env.example` updated to reflect `plura.db` filename and removed `SLACK_APP_TOKEN`